### PR TITLE
correct formula and fix typo

### DIFF
--- a/11_Throughput/Source_code/01matrix_transpose/01matrix_transpose.cu
+++ b/11_Throughput/Source_code/01matrix_transpose/01matrix_transpose.cu
@@ -118,7 +118,7 @@ void onDevice( Matrix<int> h_a, Matrix<int> h_b ){
 	HANDLER_ERROR_MSG("kernel panic!!!");
    	timer.Stop(); 
     printf( "Time Device serial:  %f ms\n", timer.Elapsed() );
-    bandwith(N, timer.Elapsed());
+    bandwidth(N, timer.Elapsed());
     // copy data back from the GPU to the CPU
 	HANDLER_ERROR_ERR(cudaMemcpy(h_b.elements, d_b.elements, ARRAY_BYTES, cudaMemcpyDeviceToHost));	
 	compareResults(h_a, h_b);
@@ -131,7 +131,7 @@ void onDevice( Matrix<int> h_a, Matrix<int> h_b ){
 	transposedMatrixKernel_threads<<<1,THREADS>>>( d_a, d_b,  THREADS);
    	timer.Stop();
     printf( "Time Device threads:  %f ms\n", timer.Elapsed() );
-   	bandwith(N, timer.Elapsed()); 
+   	bandwidth(N, timer.Elapsed()); 
     // copy data back from the GPU to the CPU
 	HANDLER_ERROR_ERR(cudaMemcpy(h_b.elements, d_b.elements, ARRAY_BYTES, cudaMemcpyDeviceToHost));	
 	compareResults(h_a, h_b);
@@ -145,7 +145,7 @@ void onDevice( Matrix<int> h_a, Matrix<int> h_b ){
     HANDLER_ERROR_MSG("kernel panic!!!");
    	timer.Stop();  	
     printf( "Time Device threads and blocks:  %f ms\n", timer.Elapsed() );
-    bandwith(N, timer.Elapsed()); 
+    bandwidth(N, timer.Elapsed()); 
     // copy data back from the GPU to the CPU
 	HANDLER_ERROR_ERR(cudaMemcpy(h_b.elements, d_b.elements, ARRAY_BYTES, cudaMemcpyDeviceToHost));	
 	compareResults(h_a, h_b);

--- a/11_Throughput/Source_code/01matrix_transpose/common/Utilities.h
+++ b/11_Throughput/Source_code/01matrix_transpose/common/Utilities.h
@@ -4,7 +4,7 @@
 #include <stdio.h>     
 
 
-void bandwith(int n, float time){
+void bandwidth(int n, float time){
 
 	cudaDeviceProp  prop;
 

--- a/11_Throughput/Source_code/01matrix_transpose/common/Utilities.h
+++ b/11_Throughput/Source_code/01matrix_transpose/common/Utilities.h
@@ -12,8 +12,8 @@ void bandwidth(int n, float time){
 
 	cudaGetDeviceProperties( &prop, 0 );
 
-	tbw = (((prop.memoryClockRate * 10e2f) * (prop.memoryBusWidth/8))*2)/10e9f;
-	efbw = ((n*n*4*2)/10e9)/(time*10e-4f);
+	tbw = (((prop.memoryClockRate * 1e3f) * (prop.memoryBusWidth/8))*2)/1e9f;
+	efbw = ((n*n*4*2)/1e9)/(time*1e-3f);
 	ram = (efbw / tbw)*100;
 
 	printf("TBw = %.3f GB/s, EBw = %.3f GB/s, RAM Utilization = %.2f %%  \n", tbw, efbw, ram);


### PR DESCRIPTION
The theoretical bandwidth calculated on my GTX 1080 was `32.032 GB/s`, but according to https://www.geforce.co.uk/hardware/desktop-gpus/geforce-gtx-1080/specifications, it should be `320 GB/s`.  That's because when converting Bytes to GB, `(prop.memoryBusWidth/8))*2)` is divided by 10e9(=10^10) rather than 10^9: https://github.com/eegkno/CUDA_by_practice/blob/ca48e9b2a52b1d3ddfdc52517858ceb54c38fa1d/11_Throughput/Source_code/01matrix_transpose/common/Utilities.h#L15

This PR fixes it.